### PR TITLE
:bug: fix(core): stop auto-zoom on input fields on iOS browsers (#223)

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,7 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <!-- Don't allow user zooming to avoid auto-zoom on Safari browsers on small input text -->
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=0"
+    />
     <link rel="icon" id="favicon" href="<%= BASE_URL %>favicon.png" />
     <title>Clear Habits</title>
     <link


### PR DESCRIPTION
Since Safari/iOS mobile browsers automatically zoom on input fields when the font size is under 16px, since we have a responsive design, we can remove this by setting the maximum-scale of the viewport.

Notably, this may be not be great for accessibility, so might need changing in the future.