### PR TITLE
:bug: fix(ScrollArea): stop scroll width from exceeding parent (#330)

### DIFF
--- a/client-ui-thing/components/ui/ScrollArea/Viewport.vue
+++ b/client-ui-thing/components/ui/ScrollArea/Viewport.vue
@@ -16,6 +16,6 @@
   >();
 
   const styles = tv({
-    base: "h-full w-full rounded-[inherit]",
   });
+    base: "h-full w-full rounded-[inherit] [&>div]:!block",
 </script>


### PR DESCRIPTION
The scroll area child was setting `display: table` which was causing the scroll area to exceed the width of the parent. This commit forces a `display: block` style instead.